### PR TITLE
Fix old universal login

### DIFF
--- a/auth0_component/__init__.py
+++ b/auth0_component/__init__.py
@@ -21,9 +21,6 @@ from jose import jwt
 
 def getVerifiedSubFromToken(token, domain):
     domain = "https://"+domain
-    if domain[-10:] != '.auth0.com':
-        print('domain should end with ".us.auth0.com" (no slash)')
-        raise ValueError
     jsonurl = urlopen(domain+"/.well-known/jwks.json")
     jwks = json.loads(jsonurl.read())
     unverified_header = jwt.get_unverified_header(token)

--- a/auth0_component/__init__.py
+++ b/auth0_component/__init__.py
@@ -21,6 +21,9 @@ from jose import jwt
 
 def getVerifiedSubFromToken(token, domain):
     domain = "https://"+domain
+    if domain[-10:] != '.auth0.com':
+        print('domain should end with ".us.auth0.com" (no slash)')
+        raise ValueError
     jsonurl = urlopen(domain+"/.well-known/jwks.json")
     jwks = json.loads(jsonurl.read())
     unverified_header = jwt.get_unverified_header(token)

--- a/auth0_component/__init__.py
+++ b/auth0_component/__init__.py
@@ -105,3 +105,4 @@ if not _RELEASE:
     st.write(user_info)
     if st.button('rerun'):
         st.experimental_rerun()
+

--- a/auth0_component/__init__.py
+++ b/auth0_component/__init__.py
@@ -21,9 +21,6 @@ from jose import jwt
 
 def getVerifiedSubFromToken(token, domain):
     domain = "https://"+domain
-    if domain[-13:] != '.us.auth0.com':
-        print('domain should end with ".us.auth0.com" (no slash)')
-        raise ValueError
     jsonurl = urlopen(domain+"/.well-known/jwks.json")
     jwks = json.loads(jsonurl.read())
     unverified_header = jwt.get_unverified_header(token)

--- a/auth0_component/frontend/src/App.js
+++ b/auth0_component/frontend/src/App.js
@@ -44,7 +44,6 @@ class App extends StreamlitComponentBase {
   onRun = (user, token) => {
     if (!_.isEqual(user, this.state.user)) {
       if (user) user['token'] = token
-      console.log("Sending data back to streamlit " + JSON.stringify(user))
       Streamlit.setComponentValue(user)
       this.setState({ user: user })
     }

--- a/auth0_component/frontend/src/App.js
+++ b/auth0_component/frontend/src/App.js
@@ -1,11 +1,11 @@
-import React from "react";
-import { Router } from "react-router-dom";
-import { Auth0Provider } from "@auth0/auth0-react";
-import NavBar from "./components/NavBar";
-import history from "./utils/history";
+import React from "react"
+import { Router } from "react-router-dom"
+import { Auth0Provider } from "@auth0/auth0-react"
+import NavBar from "./components/NavBar"
+import history from "./utils/history"
 import {
   Button,
-} from "reactstrap";
+} from "reactstrap"
 
 import {
   Streamlit,
@@ -14,56 +14,54 @@ import {
 } from "streamlit-component-lib"
 
 // styles
-import "./App.css";
+import "./App.css"
 
 // fontawesome
-import initFontAwesome from "./utils/initFontAwesome";
-var _ = require('lodash');
+import initFontAwesome from "./utils/initFontAwesome"
 
-initFontAwesome();
+var _ = require("lodash")
+
+initFontAwesome()
+
 class App extends StreamlitComponentBase {
 
-  constructor(props){
+  constructor(props) {
     super(props)
-    this.state = { user: null };
+    this.state = { user: null }
   }
+  domain = this.props['args']['auth_setup']['domain']
+  clientId = this.props['args']['auth_setup']['clientId']
 
   providerConfig = {
-    domain: this.props['args']['auth_setup']['domain'],
-    clientId: this.props['args']['auth_setup']['clientId'],
+    clientId: this.clientId,
+    domain: this.domain,
+    audience: `https://${this.domain}/api/v2/`,
     redirectUri: window.location.origin,
-  };
-
-  onRun = (user) => { 
-    if (! _.isEqual(user, this.state.user)){        
-          if (! user){
-            Streamlit.setComponentValue(user)
-            this.setState({user: user})
-          }
-
-          else {
-            user['token']().then(
-              (token) => {
-                user['token'] = token;
-                Streamlit.setComponentValue(user)
-                this.setState({user: user})
-              }
-            )
-          }
-      } 
+    useRefreshTokens: true,
+    cacheLocation: "localstorage",
   }
 
-  render(){
+  onRun = (user, token) => {
+    if (!_.isEqual(user, this.state.user)) {
+      if (user) user['token'] = token
+      console.log("Sending data back to streamlit " + JSON.stringify(user))
+      Streamlit.setComponentValue(user)
+      this.setState({ user: user })
+    }
+  }
+
+  render() {
     return (
-    <Auth0Provider {...this.providerConfig}>
-        <div id="app" >
-          <NavBar props = {{onRun : this.onRun, domain: this.props['args']['auth_setup']['domain']}} />
+      <Auth0Provider {...this.providerConfig}>
+        <div id="app">
+          <NavBar props={{ onRun: this.onRun, domain: this.providerConfig.domain }} />
         </div>
       </Auth0Provider>
-    );
-  }}
+    )
+  }
+}
 
-// export default App;
+// export default App
 export default withStreamlitConnection(App)
 
 

--- a/auth0_component/frontend/src/components/NavBar.css
+++ b/auth0_component/frontend/src/components/NavBar.css
@@ -1,7 +1,7 @@
 .nav-container {
-  height:100px
+  height:50px
 }
 
 .login-component {
-    height:100px
+    height:50px
 }

--- a/auth0_component/frontend/src/components/NavBar.js
+++ b/auth0_component/frontend/src/components/NavBar.js
@@ -30,7 +30,7 @@ const NavBar = (props) => {
 
   const logoutWithRedirect = () =>
     logout({
-      returnTo: window.location,
+      returnTo: window.location.origin,
     })
 
 

--- a/auth0_component/frontend/src/index.js
+++ b/auth0_component/frontend/src/index.js
@@ -3,31 +3,9 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
-import { Auth0Provider } from "@auth0/auth0-react";
-import history from "./utils/history";
-// import { getConfig } from "./config";
-
-const onRedirectCallback = (appState) => {
-  history.push(
-    appState && appState.returnTo ? appState.returnTo : window.location.pathname
-  );
-};
-
-// Please see https://auth0.github.io/auth0-react/interfaces/auth0_provider.auth0provideroptions.html
-// for a full list of the available properties on the provider
-
-// const providerConfig = {
-//   domain: config.domain,
-//   clientId: config.clientId,
-//   ...(config.audience ? { audience: config.audience } : null),
-//   redirectUri: window.location.origin,
-//   onRedirectCallback,
-// };
 
 ReactDOM.render(
-  // <Auth0Provider {...providerConfig}>
     <App />
-  // </Auth0Provider>,
   ,
   document.getElementById("root")
 );


### PR DESCRIPTION
This didn't work with the old universal login where it had an issue with getting access token silently  (as opposed to with a popup).  It worked fine with the "new" universal login though.

This PR:

- Fixes the Login Required error which was being raised for getAccessTokenSilently
- Adds some state to the NavBar component to make sure it doesn't always try to get the new token as instructed by @conradbez 
- Some small refactorings and cleanup




Fixes #1 