### PR TITLE
Redirect to iframe src when logging out

### DIFF
--- a/auth0_component/frontend/src/components/NavBar.js
+++ b/auth0_component/frontend/src/components/NavBar.js
@@ -38,18 +38,32 @@ const NavBar = (props) => {
     getAccessTokenWithPopup
   } = useAuth0();
 
+  const getOriginUrl = () => {
+    // Detect if you're inside an iframe
+    if (window.parent !== window) {
+      const currentIframeHref = new URL(document.location.href);
+      const urlOrigin = currentIframeHref.origin;
+      const urlFilePath = decodeURIComponent(currentIframeHref.pathname);
+      // Take referrer as origin
+      return urlOrigin + urlFilePath;
+    } else {
+      return window.location.origin;
+    }
+  }
+
+
   const logoutWithRedirect = () =>
     logout({
-      returnTo: window.location.origin,
+      returnTo: getOriginUrl(),
     });
-  
+
   const getAccessToken = () => {
     return getAccessTokenSilently({
     // return getAccessTokenWithPopup({
       audience:`https://${domain}/api/v2/`,
       scope: "read:current_user",
     })
-  }  
+  }
 
 
   if (isAuthenticated){
@@ -75,7 +89,7 @@ const NavBar = (props) => {
             )}
             {isAuthenticated && (
                 <Button
-                onClick={() => {  
+                onClick={() => {
                     logoutWithRedirect()
                   }}
                 >Logout


### PR DESCRIPTION
When the `auth0_component` is imported, Streamlit creates an iframe for the frontend page.  If you are running the codebase in `RELEASE=False` mode there will be no issue because the frontend is running on a separate port.  However, when released, `window.location.origin` points to the homepage of your streamlit app.  We should redirect to the `src` of the iframe Streamlit created, which is http://mydomain.com/component/auth0_component.login_button/index.html